### PR TITLE
Remove "--without-docs" argument

### DIFF
--- a/src/hexpm-cli.erl
+++ b/src/hexpm-cli.erl
@@ -20,7 +20,7 @@ main([HelpFlag | _])
 main(["help" | Args]) ->
     run_rebar(["help", "hex" | Args]);
 main(["publish" | _] = Args) ->
-    run_rebar(["hex" | Args] ++ ["--without-docs"]);
+    run_rebar(["hex" | Args]);
 main(Args) ->
     run_rebar(["hex" | Args]).
 


### PR DESCRIPTION
This was removed in `rebar3_hex` in this commit:
https://github.com/erlef/rebar3_hex/pull/235